### PR TITLE
Add java.net repository to fetch the json-api snapshot from

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,11 @@
             <id>sonatype.snapshots</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <!-- The JSON-B API is available in this repository -->
+            <id>java.net.snapshot</id>
+            <url>https://maven.java.net/content/repositories/snapshots/</url>
+        </repository>
     </repositories>
 
 </project>


### PR DESCRIPTION
The build failed on clean environments when the json api jar file doesn't exist in local maven repository
