### PR TITLE
Added missing dependecy for yasson & Gson Benchmark tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,16 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.8.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.15</jmh.version>
+        <jmh.version>1.19</jmh.version>
         <javac.target>1.8</javac.target>
         <uberjar.name>benchmarks</uberjar.name>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>yasson</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.1</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/org/istanbuljug/json/ConvertCollectionBenchmark.java
+++ b/src/main/java/org/istanbuljug/json/ConvertCollectionBenchmark.java
@@ -2,6 +2,7 @@ package org.istanbuljug.json;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
@@ -32,6 +33,7 @@ public class ConvertCollectionBenchmark {
 
     private Jsonb jsonb;
     private ObjectMapper objectMapper;
+    private Gson gson;
 
     private List<String> colors;
 
@@ -42,6 +44,7 @@ public class ConvertCollectionBenchmark {
     public void init() {
         jsonb = JsonbBuilder.create();
         objectMapper = new ObjectMapper();
+        gson = new Gson();
         colors = new ArrayList<>(Arrays.asList("Ali", "Veli", "Selami"));
         listClass = new ArrayList<String>() {
         }.getClass();
@@ -66,6 +69,16 @@ public class ConvertCollectionBenchmark {
         String colorsJsonArray = objectMapper.writeValueAsString(colors);
 
         return objectMapper.readValue(colorsJsonArray, listType);
+    }
+
+    @Benchmark
+    @Fork(value = FORK_COUNT)
+    @Warmup(iterations = WARMUP_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    public List<String> gson_to_from_list() throws IOException {
+        String colorsJsonArray = gson.toJson(colors);
+
+        return gson.fromJson(colorsJsonArray, listClass);
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/main/java/org/istanbuljug/json/ConvertMapBenchmark.java
+++ b/src/main/java/org/istanbuljug/json/ConvertMapBenchmark.java
@@ -2,6 +2,7 @@ package org.istanbuljug.json;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
@@ -29,6 +30,7 @@ public class ConvertMapBenchmark {
 
     private Jsonb jsonb;
     private ObjectMapper objectMapper;
+    private Gson gson;
     private Map<String, Object> jug;
 
     private TypeReference<HashMap<String, Object>> mapType;
@@ -37,6 +39,7 @@ public class ConvertMapBenchmark {
     public void init() {
         jsonb = JsonbBuilder.create();
         objectMapper = new ObjectMapper();
+        gson = new Gson();
         jug = new HashMap();
         ;
         jug.put("name", "İstanbul JUG");
@@ -62,6 +65,15 @@ public class ConvertMapBenchmark {
     public HashMap<String, Object> jackson_to_from_json() throws IOException {
         String colorsJsonArray = objectMapper.writeValueAsString(jug);
         return objectMapper.readValue(colorsJsonArray, mapType);
+    }
+
+    @Benchmark
+    @Fork(value = FORK_COUNT)
+    @Warmup(iterations = WARMUP_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    public HashMap<String, Object> gson_to_from_json() throws IOException {
+        String colorsJsonArray = gson.toJson(jug);
+        return gson.fromJson(colorsJsonArray, mapType.getType());
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/main/java/org/istanbuljug/json/DeserializeBenchmark.java
+++ b/src/main/java/org/istanbuljug/json/DeserializeBenchmark.java
@@ -1,6 +1,7 @@
 package org.istanbuljug.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.results.RunResult;
 import org.openjdk.jmh.runner.Runner;
@@ -28,12 +29,14 @@ public class DeserializeBenchmark {
 
     private Jsonb jsonb;
     private ObjectMapper objectMapper;
+    private Gson gson;
     private String jug;
 
     @Setup(Level.Trial)
     public void init() {
         jsonb = JsonbBuilder.create();
         objectMapper = new ObjectMapper();
+        gson = new Gson();
         jug = "{\"name\":\"İstanbul JUG\",\"year\":2010}";
     }
 
@@ -41,7 +44,7 @@ public class DeserializeBenchmark {
     @Fork(value = FORK_COUNT)
     @Warmup(iterations = WARMUP_COUNT)
     @Measurement(iterations = ITERATION_COUNT)
-    public Jug json_to_jsonb() {
+    public Jug jsonb_from_json() {
         return jsonb.fromJson(jug, Jug.class);
     }
 
@@ -49,8 +52,16 @@ public class DeserializeBenchmark {
     @Fork(value = FORK_COUNT)
     @Warmup(iterations = WARMUP_COUNT)
     @Measurement(iterations = ITERATION_COUNT)
-    public Jug json_to_jackson() throws IOException {
+    public Jug jackson_from_json() throws IOException {
         return objectMapper.readValue(jug, Jug.class);
+    }
+
+    @Benchmark
+    @Fork(value = FORK_COUNT)
+    @Warmup(iterations = WARMUP_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    public Jug gson_from_json() throws IOException {
+        return gson.fromJson(jug, Jug.class);
     }
 
     public static void main(String[] args) throws RunnerException {

--- a/src/main/java/org/istanbuljug/json/SerializeBenchmark.java
+++ b/src/main/java/org/istanbuljug/json/SerializeBenchmark.java
@@ -2,6 +2,7 @@ package org.istanbuljug.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.results.RunResult;
@@ -29,12 +30,14 @@ public class SerializeBenchmark {
 
     private Jsonb jsonb;
     private ObjectMapper objectMapper;
+    private Gson gson;
     private Jug jug;
 
     @Setup(Level.Trial)
     public void init() {
         jsonb = JsonbBuilder.create();
         objectMapper = new ObjectMapper();
+        gson = new Gson();
         jug = new Jug("İstanbul JUG", 2010);
     }
 
@@ -53,6 +56,15 @@ public class SerializeBenchmark {
     @Measurement(iterations = ITERATION_COUNT)
     public void jackson_to_json(Blackhole blackhole) throws JsonProcessingException {
         String json = objectMapper.writeValueAsString(jug);
+        blackhole.consume(json);
+    }
+
+    @Benchmark
+    @Fork(value = FORK_COUNT)
+    @Warmup(iterations = WARMUP_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    public void gson_to_json(Blackhole blackhole) throws JsonProcessingException {
+        String json = gson.toJson(jug);
         blackhole.consume(json);
     }
 

--- a/src/main/java/org/istanbuljug/json/SerializeWithStackProfiler.java
+++ b/src/main/java/org/istanbuljug/json/SerializeWithStackProfiler.java
@@ -2,6 +2,7 @@ package org.istanbuljug.json;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.StackProfiler;
@@ -29,12 +30,14 @@ public class SerializeWithStackProfiler {
 
     private Jsonb jsonb;
     private ObjectMapper objectMapper;
+    private Gson gson;
     private Jug jug;
 
     @Setup(Level.Trial)
     public void init() {
         jsonb = JsonbBuilder.create();
         objectMapper = new ObjectMapper();
+        gson = new Gson();
         jug = new Jug("İstanbul JUG", 2010);
     }
 
@@ -53,6 +56,15 @@ public class SerializeWithStackProfiler {
     @Measurement(iterations = ITERATION_COUNT)
     public void jackson_to_json(Blackhole blackhole) throws JsonProcessingException {
         String json = objectMapper.writeValueAsString(jug);
+        blackhole.consume(json);
+    }
+
+    @Benchmark
+    @Fork(value = FORK_COUNT)
+    @Warmup(iterations = WARMUP_COUNT)
+    @Measurement(iterations = ITERATION_COUNT)
+    public void gson_to_json(Blackhole blackhole) throws JsonProcessingException {
+        String json = gson.toJson(jug);
         blackhole.consume(json);
     }
 


### PR DESCRIPTION
The project at runtime was giving this exception:

# Run progress: 10.19% complete, ETA 00:00:47
# Fork: 2 of 10
# Warmup Iteration   1:  === setup deserialize ===
<failure>

**javax.json.bind.JsonbException: JSON Binding provider org.eclipse.yasson.JsonBindingProvider not found**
	at javax.json.bind.spi.JsonbProvider.provider(JsonbProvider.java:114)
	at javax.json.bind.JsonbBuilder.create(JsonbBuilder.java:108)
	at org.eclipselink.jsonb.tests.DeserializeSimple.setUp(DeserializeSimple.java:68)
	at org.eclipselink.jsonb.tests.generated.DeserializeSimple_test2Jackson_jmhTest._jmh_tryInit_f_deserializesimple0_0(DeserializeSimple_test2Jackson_jmhTest.java:326)
	at org.eclipselink.jsonb.tests.generated.DeserializeSimple_test2Jackson_jmhTest.test2Jackson_Throughput(DeserializeSimple_test2Jackson_jmhTest.java:69)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:464)
	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:448)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.eclipse.yasson.JsonBindingProvider
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at javax.json.bind.spi.JsonbProvider.provider(JsonbProvider.java:111)
	... 16 more
